### PR TITLE
Implemented check for duplicate import of artifact in one Control File

### DIFF
--- a/src/main/java/com/javaseekersback/api/model/dto/Artifact.java
+++ b/src/main/java/com/javaseekersback/api/model/dto/Artifact.java
@@ -2,6 +2,8 @@ package com.javaseekersback.api.model.dto;
 
 import com.javaseekersback.api.model.enums.ArtifactType;
 
+import java.util.Objects;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,4 +20,21 @@ public class Artifact {
     private String name;
 
     private String path;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Artifact artifact = (Artifact) o;
+        return path.equals(artifact.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path);
+    }
 }

--- a/src/main/java/com/javaseekersback/service/checks/ControlArtifactDuplicateCheck.java
+++ b/src/main/java/com/javaseekersback/service/checks/ControlArtifactDuplicateCheck.java
@@ -1,0 +1,43 @@
+package com.javaseekersback.service.checks;
+
+import com.javaseekersback.api.model.dto.Artifact;
+import com.javaseekersback.service.checks.enums.ArtifactCheckCode;
+import com.javaseekersback.service.checks.enums.CheckResultStatus;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ControlArtifactDuplicateCheck implements ControlCheck {
+
+    private static final String SUCCESS_RESULT = "Artifact Imported once.";
+    private static final String ERROR_RESULT = "Imported more than one time: ";
+
+    @Override
+    public ArtifactCheckResult check(Artifact checkArtifact, List<Artifact> controlArtifacts) {
+        if (controlArtifacts.isEmpty()) {
+            return ArtifactCheckResult.builder()
+                    .checkStatus(CheckResultStatus.SKIPPED)
+                    .checkCode(ArtifactCheckCode.DUPLICATE_IMPORT)
+                    .build();
+        }
+        long countImports = controlArtifacts.stream()
+                .filter(checkArtifact::equals)
+                .count();
+        //also can check in other controls
+        if (countImports > 1) {
+            return ArtifactCheckResult.builder()
+                    .checkStatus(CheckResultStatus.ERROR)
+                    .checkCode(ArtifactCheckCode.DUPLICATE_IMPORT)
+                    .actualResultMessage(ERROR_RESULT + countImports + " time(s)")
+                    .build();
+
+        }
+        return ArtifactCheckResult.builder()
+                .checkStatus(CheckResultStatus.SUCCESS)
+                .checkCode(ArtifactCheckCode.DUPLICATE_IMPORT)
+                .actualResultMessage(SUCCESS_RESULT)
+                .build();
+    }
+}

--- a/src/main/java/com/javaseekersback/service/checks/ControlCheck.java
+++ b/src/main/java/com/javaseekersback/service/checks/ControlCheck.java
@@ -1,0 +1,10 @@
+package com.javaseekersback.service.checks;
+
+import com.javaseekersback.api.model.dto.Artifact;
+
+import java.util.List;
+
+public interface ControlCheck {
+
+    ArtifactCheckResult check(Artifact checkArtifact, List<Artifact> controlArtifacts);
+}

--- a/src/main/java/com/javaseekersback/service/checks/ControlCheckSuite.java
+++ b/src/main/java/com/javaseekersback/service/checks/ControlCheckSuite.java
@@ -1,9 +1,7 @@
 package com.javaseekersback.service.checks;
 
 import com.javaseekersback.api.model.dto.Artifact;
-import com.javaseekersback.api.model.enums.ArtifactType;
 import com.javaseekersback.api.model.response.ArtifactCheckResponse;
-import com.javaseekersback.service.checks.enums.ArtifactCheckCode;
 import com.javaseekersback.service.checks.enums.CheckResultStatus;
 
 import org.springframework.stereotype.Component;
@@ -18,32 +16,33 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class ControlCheckSuite {
 
+    private final ControlImportOrderCheck controlImportOrderCheck;
+    private final ControlArtifactDuplicateCheck controlDuplicateArtifact;
+
+    public ControlCheckSuite(ControlImportOrderCheck controlImportOrderCheck, ControlArtifactDuplicateCheck controlDuplicateArtifact) {
+        this.controlImportOrderCheck = controlImportOrderCheck;
+        this.controlDuplicateArtifact = controlDuplicateArtifact;
+    }
+
     public List<ArtifactCheckResponse> getErrors(List<Artifact> artifacts) {
-        //TODO: think to create separate check
         List<ArtifactCheckResponse> results = new ArrayList<>();
 
         for (Artifact artifact : artifacts) {
-            List<Artifact> artifactsImportedAfter = artifacts.subList(artifacts.indexOf(artifact) + 1, artifacts.size());
-            List<Artifact> artifactsDependent = artifactsImportedAfter.stream()
-                    .filter(a -> artifact.getType().getDependencies().contains(a.getType()))
+            List<ArtifactCheckResult> artifactCheckResults = new ArrayList<>();
+
+            artifactCheckResults.add(controlImportOrderCheck.check(artifact, artifacts));
+            artifactCheckResults.add(controlDuplicateArtifact.check(artifact, artifacts));
+
+            List<ArtifactCheckResult> artifactErrorCheckResults = artifactCheckResults.stream()
+                    .filter(r -> CheckResultStatus.ERROR.equals(r.getCheckStatus()))
                     .collect(Collectors.toList());
 
-            if (!artifactsDependent.isEmpty()) {
-                String errorDetails = artifact.getType().getDependencies()
-                        .stream()
-                        .map(ArtifactType::getTypeName)
-                        .collect(Collectors.joining(", "));
-                ArtifactCheckResponse artifactErrorResponse = ArtifactCheckResponse.builder()
-                        .name(artifact.getName())
-                        .type(artifact.getType())
-                        .path(artifact.getPath())
-                        .artifactErrorChecks(List.of(ArtifactCheckResult.builder()
-                                .checkStatus(CheckResultStatus.ERROR)
-                                .checkCode(ArtifactCheckCode.IMPORT_ORDER)
-                                .actualResultMessage("Must be imported after next groups: " + errorDetails)
-                                .build())).build();
-                results.add(artifactErrorResponse);
-            }
+            ArtifactCheckResponse artifactErrorResponse = ArtifactCheckResponse.builder()
+                    .name(artifact.getName())
+                    .type(artifact.getType())
+                    .path(artifact.getPath())
+                    .artifactErrorChecks(artifactErrorCheckResults).build();
+            results.add(artifactErrorResponse);
         }
         return results;
     }

--- a/src/main/java/com/javaseekersback/service/checks/ControlImportOrderCheck.java
+++ b/src/main/java/com/javaseekersback/service/checks/ControlImportOrderCheck.java
@@ -1,0 +1,50 @@
+package com.javaseekersback.service.checks;
+
+import com.javaseekersback.api.model.dto.Artifact;
+import com.javaseekersback.api.model.enums.ArtifactType;
+import com.javaseekersback.service.checks.enums.ArtifactCheckCode;
+import com.javaseekersback.service.checks.enums.CheckResultStatus;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+
+@Component
+public class ControlImportOrderCheck implements ControlCheck {
+
+    private static final String SUCCESS_RESULT = "Correct import order";
+
+    @Override
+    public ArtifactCheckResult check(@NotNull Artifact checkArtifact, @NotNull List<Artifact> controlArtifacts) {
+        if (controlArtifacts.isEmpty()) {
+            return ArtifactCheckResult.builder()
+                    .checkStatus(CheckResultStatus.SKIPPED)
+                    .checkCode(ArtifactCheckCode.IMPORT_ORDER)
+                    .build();
+        }
+        List<Artifact> artifactsImportedAfter = controlArtifacts.subList(controlArtifacts.indexOf(checkArtifact) + 1, controlArtifacts.size());
+        List<Artifact> artifactsDependent = artifactsImportedAfter.stream()
+                .filter(a -> checkArtifact.getType().getDependencies().contains(a.getType()))
+                .collect(Collectors.toList());
+
+        if (!artifactsDependent.isEmpty()) {
+            String errorDetails = checkArtifact.getType().getDependencies()
+                    .stream()
+                    .map(ArtifactType::getTypeName)
+                    .collect(Collectors.joining(", "));
+            return ArtifactCheckResult.builder()
+                    .checkStatus(CheckResultStatus.ERROR)
+                    .checkCode(ArtifactCheckCode.IMPORT_ORDER)
+                    .actualResultMessage("Must be imported after next groups: " + errorDetails)
+                    .build();
+        }
+        return ArtifactCheckResult.builder()
+                .checkStatus(CheckResultStatus.SUCCESS)
+                .checkCode(ArtifactCheckCode.IMPORT_ORDER)
+                .actualResultMessage(SUCCESS_RESULT)
+                .build();
+    }
+}

--- a/src/main/java/com/javaseekersback/service/checks/enums/ArtifactCheckCode.java
+++ b/src/main/java/com/javaseekersback/service/checks/enums/ArtifactCheckCode.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum ArtifactCheckCode {
     PRESENT_IN_FILE_SYSTEM_CHECK("Present in file System"),
     FILE_WELL_FORMED("File well formed"),
-    IMPORT_ORDER("Artifact imported in correct order");
+    IMPORT_ORDER("Artifact imported in correct order"),
+    DUPLICATE_IMPORT("Artifact Imported once");
 
     private final String checkName;
 

--- a/src/main/java/com/javaseekersback/service/impl/ArtifactsServiceImpl.java
+++ b/src/main/java/com/javaseekersback/service/impl/ArtifactsServiceImpl.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -105,19 +106,11 @@ public class ArtifactsServiceImpl implements ArtifactsService {
         List<ArtifactCheckResponse> controlFileErrors = controlCheckSuite.getErrors(artifacts);
         artifactErrors.addAll(
                 controlFileErrors.stream()
-                        .filter(acr -> acr.getPath().equals(artifact.getPath()))
+                        .filter(artError -> Objects.equals(artError.getPath(), artifact.getPath()))
                         .findFirst()
                         .map(ArtifactCheckResponse::getArtifactErrorChecks)
                         .orElseGet(Collections::emptyList));
         return artifactErrors;
-    }
-
-    /**
-     * @param controlFilePath relative path to file
-     */
-    private List<ArtifactCheckResponse> getControlFileErrors(@NotNull String controlFilePath) {
-        List<Artifact> artifacts = getArtifacts(controlFilePath);
-        return controlCheckSuite.getErrors(artifacts);
     }
 
     @Override

--- a/src/main/java/com/javaseekersback/service/impl/ArtifactsServiceImpl.java
+++ b/src/main/java/com/javaseekersback/service/impl/ArtifactsServiceImpl.java
@@ -59,7 +59,7 @@ public class ArtifactsServiceImpl implements ArtifactsService {
     }
 
     private List<Artifact> getArtifacts(@NotNull String controlFilePath) {
-        log.info("getArtifacts controlFilePath={}", controlFilePath);
+        log.debug("getArtifacts controlFilePath={}", controlFilePath);
 
         Path path = Path.of(PathConstants.CONFIGURER_ABSOLUTE_PATH, PathConstants.CONFIGURER_SCHEMA_PATH, controlFilePath);
 
@@ -88,7 +88,7 @@ public class ArtifactsServiceImpl implements ArtifactsService {
                         .type(a.getType())
                         .name(a.getName())
                         .path(a.getPath())
-                        .artifactErrorChecks(collectAllArtifactErrors(request, a))
+                        .artifactErrorChecks(collectAllArtifactErrors(request, a, artifacts))
                         .build())
                 .collect(Collectors.toList());
 
@@ -100,9 +100,9 @@ public class ArtifactsServiceImpl implements ArtifactsService {
                 .build();
     }
 
-    private List<ArtifactCheckResult> collectAllArtifactErrors(ControlArtifactRequest request, Artifact artifact) {
+    private List<ArtifactCheckResult> collectAllArtifactErrors(ControlArtifactRequest request, Artifact artifact, List<Artifact> artifacts) {
         List<ArtifactCheckResult> artifactErrors = artifactCheckSuite.getErrors(Path.of(request.getClient(), artifact.getPath()).toString());
-        List<ArtifactCheckResponse> controlFileErrors = getControlFileErrors(request.asPath());
+        List<ArtifactCheckResponse> controlFileErrors = controlCheckSuite.getErrors(artifacts);
         artifactErrors.addAll(
                 controlFileErrors.stream()
                         .filter(acr -> acr.getPath().equals(artifact.getPath()))


### PR DESCRIPTION
Simple check if artifact specified more than 1 time per Control File. Can be extended to check in all control files per client

![DUPLI](https://user-images.githubusercontent.com/2931663/145551443-8f24007f-ad92-4f62-b1e3-8a906ffa1a96.png)

